### PR TITLE
Add GOV.UK blue to gov_cols

### DIFF
--- a/R/gov_cols.R
+++ b/R/gov_cols.R
@@ -39,5 +39,6 @@ gov_cols <- c(
   fuschia     = "#912B88",
   red         = "#B10E1E",
   brown       = "#B58840",
-  grass_green = "#85994B"
+  grass_green = "#85994B",
+  govuk_blue  = "#005EA5"
 )


### PR DESCRIPTION
GOV.UK is in the [extended palette](https://govuk-elements.herokuapp.com/colour/#colour-extended-palette), and is the only one so far missing from `gov_cols()`.  Unless it was omitted for a reason?