### PR TITLE
Don't use .Rprofile, explain packrat in README

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,3 +1,0 @@
-#### -- Packrat Autoloader (version 0.4.8-1) -- ####
-source("packrat/init.R")
-#### -- End Packrat Autoloader -- ####

--- a/README.Rmd
+++ b/README.Rmd
@@ -30,6 +30,10 @@ For testing purposes (not general usage), the package `visualTest` is required.
 This can be installed with `devtools::install_github('mangothecat/visualTest')`.
 For some users `devtools::install_local()` may also be required.
 
+You can create a development environment with `packrat` by running
+`source("packrat/init.R")` in a console, which will install `packrat` if
+necessary, and then all the packages defined in `/packrat/packrat.lock`.
+
 ## Functions
 
 * `theme_gov()`: Theme to be applied to plots produced in [ggplot2]() to give a government statistics publication feel.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ For testing purposes (not general usage), the package `visualTest` is required.
 This can be installed with `devtools::install_github('mangothecat/visualTest')`.
 For some users `devtools::install_local()` may also be required.
 
++You can create a development environment with `packrat` by running
++`source("packrat/init.R")` in a console, which will install `packrat` if
++necessary, and then all the packages defined in `/packrat/packrat.lock`.
++
 ## Functions
 
 * `theme_gov()`: Theme to be applied to plots produced in [ggplot2]() to give a government statistics publication feel.


### PR DESCRIPTION
The `packrat` bootstrap is clever and useful -- but it's surprising when the console starts installing stuff automatically.  It would seem better to point out `packrat` in the `README` to people who would look for it.